### PR TITLE
Added appengine support

### DIFF
--- a/.hgignore
+++ b/.hgignore
@@ -1,0 +1,14 @@
+# use glob syntax.
+syntax: glob
+
+*.settings
+*.DS_Store
+*.elc
+*.pyc
+*.tmp_*
+org.eclipse.*
+project/var*
+project/eggs*
+project/docs*
+docs*
+

--- a/wordpress_xmlrpc/base.py
+++ b/wordpress_xmlrpc/base.py
@@ -1,6 +1,7 @@
 import xmlrpclib
 import collections
 import types
+from wordpress_xmlrpc.xmlrpc import GAEXMLRPCTransport
 
 
 class Client(object):
@@ -11,13 +12,21 @@ class Client(object):
     `XmlrpcMethod`-derived class to `Client`'s `call` method.
     """
 
-    def __init__(self, url, username, password, blog_id=0):
+    def __init__(self, url, username, password, blog_id=0, appengine_mode=False):
         self.url = url
         self.username = username
         self.password = password
         self.blog_id = blog_id
-
-        self.server = xmlrpclib.ServerProxy(url, use_datetime=True, allow_none=True)
+        if not appengine_mode:
+            self.server = xmlrpclib.ServerProxy(url, use_datetime=True, allow_none=True)
+        else:
+            import urllib
+            type, uri = urllib.splittype(url)
+            self.server = xmlrpclib.ServerProxy(url, 
+                                                use_datetime=True, 
+                                                allow_none=True, 
+                                                transport=GAEXMLRPCTransport(protocol=type, 
+                                                                             use_datetime=True))
         self.supported_methods = self.server.mt.supportedMethods()
 
     def call(self, method):

--- a/wordpress_xmlrpc/xmlrpc.py
+++ b/wordpress_xmlrpc/xmlrpc.py
@@ -1,0 +1,43 @@
+import sys
+import xmlrpclib
+import logging
+
+from google.appengine.api import urlfetch
+
+class GAEXMLRPCTransport(object):
+    """Handles an HTTP transaction to an XML-RPC server."""
+
+    def __init__(self, use_datetime=0, protocol='http', content_type='text/xml'):
+        self._use_datetime = use_datetime
+        self._content_type = content_type
+        self._protocol = protocol
+
+    def request(self, host, handler, request_body, verbose=0):
+        result = None
+        url = '%s://%s%s' % (self._protocol, host, handler)
+        try:
+            response = urlfetch.fetch(url,
+                                      payload=request_body,
+                                      method=urlfetch.POST,
+                                      headers={'Content-Type': self._content_type})
+        except:
+            msg = 'Failed to fetch %s' % url
+            logging.error(msg)
+            raise xmlrpclib.ProtocolError(host + handler, 500, msg, {})
+
+        if response.status_code != 200:
+            logging.error('%s returned status code %s' % 
+                          (url, response.status_code))
+            raise xmlrpclib.ProtocolError(host + handler,
+                                          response.status_code,
+                                          "",
+                                          response.headers)
+        else:
+            result = self.__parse_response(response.content)
+
+        return result
+
+    def __parse_response(self, response_body):
+        p, u = xmlrpclib.getparser(use_datetime=self._use_datetime)
+        p.feed(response_body)
+        return u.close()


### PR DESCRIPTION
I added support for Appengine implementing a Transport class for xmlrpclib that uses urlfetch instead of sockets. The knowledge for doing it came from this article: http://brizzled.clapper.org/id/80/
