### PR TITLE
Kept getting unicode errors. This seemed to help.

### DIFF
--- a/wordpress_xmlrpc/wordpress.py
+++ b/wordpress_xmlrpc/wordpress.py
@@ -53,7 +53,7 @@ class WordPressBase(object):
         return data
 
     def __repr__(self):
-        return '<%s: %s>' % (self.__class__.__name__, str(self))
+        return '<%s: %s>' % (self.__class__.__name__, unicode(self).encode('utf-8'))
 
 
 class WordPressPost(WordPressBase):


### PR DESCRIPTION
Added a small change to the string representation of the WordPressBase class to make sure that it's returning unicode.
