### PR TITLE
missing sys module in base.py

### DIFF
--- a/wordpress_xmlrpc/base.py
+++ b/wordpress_xmlrpc/base.py
@@ -1,4 +1,5 @@
 import collections
+import sys
 
 from wordpress_xmlrpc.compat import xmlrpc_client, dict_type
 from wordpress_xmlrpc.exceptions import ServerConnectionError, UnsupportedXmlrpcMethodError, InvalidCredentialsError, XmlrpcDisabledError


### PR DESCRIPTION
If there is any xmlrpc protocol error, sys module is missing in the base.py. I added it. 
