### PR TITLE
Add support for comment that do not provide credentials

### DIFF
--- a/wordpress_xmlrpc/methods/comments.py
+++ b/wordpress_xmlrpc/methods/comments.py
@@ -29,6 +29,19 @@ class NewComment(AuthenticatedMethod):
     method_name = 'wp.newComment'
     method_args = ('post_id', 'comment')
 
+class NewAnonymousComment(AnonymousMethod):
+    """
+    Create a new comment on a post without authenticating.
+
+    Parameters:
+        `post_id`: The id of the post to add a comment to.
+        `comment`: A :class:`WordPressComment` instance with at least the `content` value set.
+
+    Returns: ID of the newly-created comment (an integer).
+    """
+    method_name = 'wp.newComment'
+    method_args = ('post_id', 'comment')    
+
 
 class EditComment(AuthenticatedMethod):
     """


### PR DESCRIPTION
Not all comments need to be authenticated.

From http://codex.wordpress.org/XML-RPC_WordPress_API/Comments#wp.newComment

Note on Anonymous Comments
By default, the username and password parameters are required. However, if you wish to allow anonymous comments, you can use the xmlrpc_allow_anonymous_comments filter:

<pre>
add_filter( 'xmlrpc_allow_anonymous_comments', '__return_true' );
</pre>
