### PR TITLE
Workaround a bug encountered when fetching old draft posts

### DIFF
--- a/tests/test_fieldmaps.py
+++ b/tests/test_fieldmaps.py
@@ -34,3 +34,12 @@ class FieldMapsTestCase(unittest.TestCase):
             'dateCreated': xmlrpc_client.DateTime('-0001113TT0::0::00'),
         }
         self.assertRaises(FieldConversionError, SampleModel, response)
+
+    @attr('fieldmaps')
+    def test_empty_date_with_timezone_is_accepted(self):
+        response = {
+            'dateCreated': xmlrpc_client.DateTime('00000000T00:00:00Z'),
+        }
+        obj = SampleModel(response)
+        self.assertTrue(hasattr(obj, 'date_created'))
+        self.assertEqual(obj.date_created, datetime.datetime(1, 1, 1, 0, 0))


### PR DESCRIPTION
Previous versions of Wordpress did not set a date on draft posts which would result in a value of 00000000T00:00:00Z in the xmlrpc call. This value triggers bug http://bugs.python.org/issue2623 in python's xmlrpclib.

The patch comes with a new test in test_fieldmaps.py
