### PR TITLE
Add Support for Timeout Parameter

### DIFF
--- a/wordpress_xmlrpc/base.py
+++ b/wordpress_xmlrpc/base.py
@@ -1,40 +1,9 @@
 import collections
-import httplib
-import socket
 import sys
-import xmlrpclib
 
 from wordpress_xmlrpc.compat import xmlrpc_client, dict_type
 from wordpress_xmlrpc.exceptions import ServerConnectionError, UnsupportedXmlrpcMethodError, InvalidCredentialsError, XmlrpcDisabledError
-
-
-class TimeoutHTTPConnection(httplib.HTTPConnection):
-
-    def connect(self):
-        httplib.HTTPConnection.connect(self)
-        self.sock.settimeout(self.timeout)
-
-
-class TimeoutHTTP(httplib.HTTP):
-    _connection_class = TimeoutHTTPConnection
-
-    def set_timeout(self, timeout):
-        self._conn.timeout = timeout
-
-
-class TimeoutTransport(xmlrpclib.Transport):
-
-    def __init__(self, timeout=socket._GLOBAL_DEFAULT_TIMEOUT, *args, **kwargs):
-        xmlrpclib.Transport.__init__(self, *args, **kwargs)
-        self.timeout = timeout
-
-    def make_connection(self, host):
-        if self._connection and host == self._connection[0]:
-            return self._connection[1]
-
-        chost, self._extra_headers, x509 = self.get_host_info(host)
-        self._connection = host, httplib.HTTPConnection(chost)
-        return self._connection[1]
+from wordpress_xmlrpc.timeout_transport import TimeoutTransport
 
 
 class Client(object):

--- a/wordpress_xmlrpc/timeout_transport.py
+++ b/wordpress_xmlrpc/timeout_transport.py
@@ -1,0 +1,33 @@
+import httplib
+import socket
+import xmlrpclib
+
+
+class TimeoutHTTPConnection(httplib.HTTPConnection):
+
+    def connect(self):
+        httplib.HTTPConnection.connect(self)
+        self.sock.settimeout(self.timeout)
+
+
+class TimeoutHTTP(httplib.HTTP):
+    _connection_class = TimeoutHTTPConnection
+
+    def set_timeout(self, timeout):
+        self._conn.timeout = timeout
+
+
+class TimeoutTransport(xmlrpclib.Transport):
+
+    def __init__(self, timeout=socket._GLOBAL_DEFAULT_TIMEOUT,
+                 *args, **kwargs):
+        xmlrpclib.Transport.__init__(self, *args, **kwargs)
+        self.timeout = timeout
+
+    def make_connection(self, host):
+        if self._connection and host == self._connection[0]:
+            return self._connection[1]
+
+        chost, self._extra_headers, x509 = self.get_host_info(host)
+        self._connection = host, httplib.HTTPConnection(chost)
+        return self._connection[1]


### PR DESCRIPTION
We added support for a timeout parameter to the wordpress library as detailed in http://stackoverflow.com/questions/372365/set-timeout-for-xmlrpclib-serverproxy.

It seems like a good idea to allow people to specify a timeout when interacting with third party services over a network. We needed this for our project and thought we would offer back the modifications we made.
