### PR TITLE
fix WordPressComment definition

### DIFF
--- a/wordpress_xmlrpc/wordpress.py
+++ b/wordpress_xmlrpc/wordpress.py
@@ -137,7 +137,7 @@ class WordPressComment(WordPressBase):
         'user': 'user_id',
         'post': 'post_id',
         'post_title': 'post_title',
-        'parent': 'comment_parent',
+        'parent': 'parent',
         'date_created': DateTimeFieldMap('date_created_gmt'),
         'status': 'status',
         'content': FieldMap('content', default=''),

--- a/wordpress_xmlrpc/wordpress.py
+++ b/wordpress_xmlrpc/wordpress.py
@@ -137,7 +137,7 @@ class WordPressComment(WordPressBase):
         'user': 'user_id',
         'post': 'post_id',
         'post_title': 'post_title',
-        'parent': 'parent',
+        'parent': FieldMap('parent', ['comment_parent']),
         'date_created': DateTimeFieldMap('date_created_gmt'),
         'status': 'status',
         'content': FieldMap('content', default=''),


### PR DESCRIPTION
`parent` is `parent` in raw XML-RPC getComment, and `commnet_parent` in XML-RPC newComment (tested with WordPress 3.9.1)
