### PR TITLE
[IMP] Import taxonomies into `methods` root package

### DIFF
--- a/wordpress_xmlrpc/methods/__init__.py
+++ b/wordpress_xmlrpc/methods/__init__.py
@@ -8,3 +8,4 @@ from wordpress_xmlrpc.methods import users
 from wordpress_xmlrpc.methods import options
 from wordpress_xmlrpc.methods import comments
 from wordpress_xmlrpc.methods import media
+from wordpress_xmlrpc.methods import taxonomies


### PR DESCRIPTION
Minor improvement, adds import of `taxonomies` into the root `methods` package.

Before:

```
>>> from wordpress_xmlrpc import methods
>>> methods.taxonomies
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'taxonomies'
>>> dir(methods)
['__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', 'comments', 'demo', 'media', 'options', 'pages', 'posts', 'users']
```

After:
```
>>> from wordpress_xmlrpc import methods
>>> methods.taxonomies
>>> dir(methods)
['__builtins__', '__doc__', '__file__', '__name__', '__package__', '__path__', 'comments', 'demo', 'media', 'options', 'pages', 'posts', 'taxonomies', 'users']
```