### PR TITLE
WordPressPost.custom_fields is a list of dict

### DIFF
--- a/docs/ref/wordpress.rst
+++ b/docs/ref/wordpress.rst
@@ -21,7 +21,7 @@ WordPressPost
 		* ping_status
 		* terms (`list` of :class:`WordPressTerm`\s)
 		* terms_names (`dict`)
-		* custom_fields (`dict`)
+		* custom_fields (`list` of `dict`)
 		* enclosure (`dict`)
 		* password
 		* post_format


### PR DESCRIPTION
Right now it says that the property `custom_fields` is a `dict` but it actually is a `list` of `dict`.