### PR TITLE
docs: fix simple typo, ficticious -> fictitious

### DIFF
--- a/docs/overview.rst
+++ b/docs/overview.rst
@@ -67,7 +67,7 @@ or one of its subclasses (``AnonymousMethod`` or ``AuthenticatedMethod``).
 The ``XmlrpcMethod`` class provides a number of properties which you
 can override to modify the behavior of the method call.
 
-Sample class to call a custom method added by a ficticious plugin::
+Sample class to call a custom method added by a fictitious plugin::
 
 	from wordpress_xmlrpc import AuthenticatedMethod
 


### PR DESCRIPTION
There is a small typo in docs/overview.rst.

Should read `fictitious` rather than `ficticious`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md