### PR TITLE
Proper fix for module 'collections' has no attribute 'Iterable'

### DIFF
--- a/wordpress_xmlrpc/base.py
+++ b/wordpress_xmlrpc/base.py
@@ -1,8 +1,12 @@
-import collections
 import sys
 
 from wordpress_xmlrpc.compat import xmlrpc_client, dict_type
 from wordpress_xmlrpc.exceptions import ServerConnectionError, UnsupportedXmlrpcMethodError, InvalidCredentialsError, XmlrpcDisabledError
+
+try:
+    from collections.abc import Iterable  # noqa
+except ImportError:
+    from collections import Iterable  # noqa
 
 
 class Client(object):
@@ -126,7 +130,7 @@ class XmlrpcMethod(object):
         if self.results_class and raw_result:
             if isinstance(raw_result, dict_type):
                 return self.results_class(raw_result)
-            elif isinstance(raw_result, collections.Iterable):
+            elif isinstance(raw_result, Iterable):
                 return [self.results_class(result) for result in raw_result]
 
         return raw_result


### PR DESCRIPTION
This PR provides a proper fix for the bug:
```
AttributeError: module 'collections' has no attribute 'Iterable'
```
It retains compatibility with older python version.